### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v1
       - name: Docker release
-        uses: elgohr/Publish-Docker-Github-Action@main
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ismdeep/socks5-server
           username: ismdeep


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore